### PR TITLE
Fix test

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,6 +32,9 @@ class TestCase extends \Illuminate\Foundation\Testing\TestCase
         $app = require __DIR__.'/../vendor/laravel/laravel/bootstrap/app.php';
         $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
 
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite.database', ':memory:');
+        
         return $app;
     }
 
@@ -48,8 +51,6 @@ class TestCase extends \Illuminate\Foundation\Testing\TestCase
 
         $this->app['config']->set('follow', $this->config);
         $this->app['config']->set('follow.user_model', User::class);
-        $this->app['config']->set('database.default', 'sqlite');
-        $this->app['config']->set('database.connections.sqlite.database', ':memory:');
 
         $this->migrate();
         $this->seed();


### PR DESCRIPTION
`Overtrue\LaravelFollow\Test\TestCase`中由于使用了trait `DatabaseTransactions`,得在`parent::setUp()`之前配置好数据库信息，不然使用的还是默认配置导致报错