### PR TITLE
避免关系分离多次触发

### DIFF
--- a/src/Traits/CanVote.php
+++ b/src/Traits/CanVote.php
@@ -76,8 +76,8 @@ trait CanVote
      */
     public function cancelVote($targets, $class = __CLASS__)
     {
-        Follow::detachRelations($this, 'upvotes', $targets, $class);
-        Follow::detachRelations($this, 'downvotes', $targets, $class);
+        $this->hasUpvoted($targets) && Follow::detachRelations($this, 'upvotes', $targets, $class);
+        $this->hasDownvoted($targets) && Follow::detachRelations($this, 'downvotes', $targets, $class);
 
         return $this;
     }


### PR DESCRIPTION
在点赞、踩的时候会对已点赞和已踩的关联都去除，会导致关系分离事件触发了两次，做事件监听的时候处理起来比较麻烦，现在提交的 PR 是只对已有关联去除，多加了一个判断。