### PR TITLE
Fixes #80 : foreign key error message in migration now compatible with Laravel 5.8

### DIFF
--- a/database/migrations/2018_06_29_032244_create_laravel_follow_tables.php
+++ b/database/migrations/2018_06_29_032244_create_laravel_follow_tables.php
@@ -21,7 +21,15 @@ class CreateLaravelFollowTables extends Migration
     {
         Schema::create(config('follow.followable_table', 'followables'), function (Blueprint $table) {
             $userForeignKey = config('follow.users_table_foreign_key', 'user_id');
-            $table->unsignedInteger($userForeignKey);
+
+            // Laravel 5.8 session user is unsignedBigInteger
+            // https://github.com/laravel/framework/pull/28206/files
+            if ((float) app()->version() >= 5.8) {
+                $table->unsignedBigInteger($userForeignKey);
+            } else {
+                $table->unsignedInteger($userForeignKey);
+            }
+
             $table->unsignedInteger('followable_id');
             $table->string('followable_type')->index();
             $table->string('relation')->default('follow')->comment('follow/like/subscribe/favorite/upvote/downvote');


### PR DESCRIPTION
* Checks laravel version in migration file and chooses between unsignedInteger or unsignedBigInteger
* [5.8] Change session's user_id to unsigned big integer
* https://github.com/laravel/framework/pull/28206
