### PR TITLE
hasRequestedToFollow is the only function that specifies type Model on argument $user

### DIFF
--- a/src/Followable.php
+++ b/src/Followable.php
@@ -81,7 +81,7 @@ trait Followable
     /**
      * @param \Illuminate\Database\Eloquent\Model|int $user
      */
-    public function hasRequestedToFollow(Model $user): bool
+    public function hasRequestedToFollow($user): bool
     {
         if ($user instanceof Model) {
             $user = $user->getKey();


### PR DESCRIPTION


this precludes sending an integer as specified in the @property and like all the other calls that let you pass either the key or the model