### PR TITLE
Disable un-published migration

### DIFF
--- a/src/FollowServiceProvider.php
+++ b/src/FollowServiceProvider.php
@@ -15,9 +15,5 @@ class FollowServiceProvider extends ServiceProvider
         $this->publishes([
             \dirname(__DIR__) . '/migrations/' => database_path('migrations'),
         ], 'migrations');
-
-        if ($this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(\dirname(__DIR__) . '/migrations/');
-        }
     }
 }


### PR DESCRIPTION
Deleted this line of code on purpose only published migration that can be migrated.

Reference:
https://github.com/overtrue/laravel-like/issues/48