### PR TITLE
CI unit tests now working as expected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [5.x]
   pull_request:
-    branches: [master]
+    branches: [5.x]
 
 jobs:
   phpcs:
@@ -20,7 +20,7 @@ jobs:
   phpunit:
     strategy:
       matrix:
-        php_version: [8.0, 8.1]
+        php_version: [8.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CI was not working since it was expecting the branch "master" to be present. I fixed the naming and deleted PHP version colliding with PHPUnit.

CI unit testing now works and tests pass.