### PR TITLE
Added explicit nullable type to attachFollowStatus parameter

### DIFF
--- a/src/Traits/Follower.php
+++ b/src/Traits/Follower.php
@@ -117,7 +117,7 @@ trait Follower
         return $this->followings()->notAccepted();
     }
 
-    public function attachFollowStatus($followables, callable $resolver = null)
+    public function attachFollowStatus($followables, ?callable $resolver = null)
     {
         $returnFirst = false;
 


### PR DESCRIPTION
This fixes the implicitly typed nullable parameter in [PHP8.4](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)